### PR TITLE
Corrected textual description of nueral style transfer loss function.

### DIFF
--- a/8.3-neural-style-transfer.ipynb
+++ b/8.3-neural-style-transfer.ipynb
@@ -98,7 +98,7 @@
     "\"content\", and `style` is a function that takes an image and computes a representation of its \"style\".\n",
     "\n",
     "Minimizing this loss would cause `style(generated_image)` to be close to `style(reference_image)`, while `content(generated_image)` would \n",
-    "be close to `content(generated_image)`, thus achieving style transfer as we defined it.\n",
+    "be close to `content(original_image)`, thus achieving style transfer as we defined it.\n",
     "\n",
     "A fundamental observation made by Gatys et al is that deep convolutional neural networks offer precisely a way to mathematically defined \n",
     "the `style` and `content` functions. Let's see how."


### PR DESCRIPTION
The text describing the neural style transfer loss function states that minimizing the content difference between the generated image and itself is what it means to achieve transfer, but I think that it intends to say that minimizing the difference between the content of the generated image and the content of the original image is what it means to achieve transfer.